### PR TITLE
Fixed key values being read as stdObject instead of assoc array

### DIFF
--- a/Controller/FormBuilderController.php
+++ b/Controller/FormBuilderController.php
@@ -339,8 +339,8 @@ class FormBuilderController extends AbstractController
             }
 
             $header = $form->getColumns()[$key];
-            if (isset($formArray[$position]->fields->key) && $formArray[$position]->fields->key->value !== '') {
-                $header = $formArray[$position]->fields->key->value;
+            if (isset($formArray[$position]['fields']['key']) && $formArray[$position]['fields']['key']['value'] !== '') {
+                $header = $formArray[$position]['fields']['key']['value'];
             }
 
             $csvData['headers'][] = $header;


### PR DESCRIPTION
A while ago the form data was json decoded without the assoc flag, which resulted in an stdObject. The key property was still being addressed as it was an stdObject, but now this is an array because the assoc flag is now set when json decoding. Resulting in the internal keys not properly overriding the headers.