### PR TITLE
Custom submission/success text+message  and preg_match fix

### DIFF
--- a/Admin/FormBuilderAdmin.php
+++ b/Admin/FormBuilderAdmin.php
@@ -8,9 +8,8 @@ use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
 use Sonata\AdminBundle\Show\ShowMapper;
-use Sonata\CoreBundle\Validator\ErrorElement;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Symfony\Component\Validator\Constraints\Email;
 use Symfony\Component\Validator\Constraints\NotBlank;
 
 class FormBuilderAdmin extends AbstractAdmin
@@ -114,7 +113,17 @@ class FormBuilderAdmin extends AbstractAdmin
                         'required' => false,
                     ),
                 )
-            );
+            )
+            ->add('submissionTitle', 'text', [
+                'required' => false,
+                'label' => 'Custom submit title',
+                'sonata_help' => 'Customize thank you title after successful form submission',
+            ])
+            ->add('submissionText', 'textarea', [
+                'required' => false,
+                'label' => 'Custom submit text',
+                'sonata_help' => 'Customize thank you text after successful form submission',
+            ]);
     }
 
     public function getTemplate($name)

--- a/Block/FormBuilderBlockService.php
+++ b/Block/FormBuilderBlockService.php
@@ -7,9 +7,11 @@
 
 namespace Pirastru\FormBuilderBundle\Block;
 
+use Pirastru\FormBuilderBundle\Entity\FormBuilder;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\BlockBundle\Block\BlockContextInterface;
 use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\HttpFoundation\Response;
@@ -113,6 +115,8 @@ class FormBuilderBlockService extends AbstractAdminBlockService
     public function execute(BlockContextInterface $blockContext, Response $response = null)
     {
         $formBuilderId = $blockContext->getBlock()->getSetting('formBuilderId');
+
+        /** @var FormBuilder $formBuilder */
         $formBuilder = $this->container->get('doctrine')
             ->getRepository('PirastruFormBuilderBundle:FormBuilder')
             ->findOneBy(array('id' => $formBuilderId));
@@ -126,6 +130,7 @@ class FormBuilderBlockService extends AbstractAdminBlockService
         $form_pack = $this->container->get('pirastru_form_builder.controller')
             ->generateFormFromFormBuilder($formBuilder);
 
+        /** @var Form $form */
         $form = $form_pack['form'];
         $success = false;
         $request = $this->container->get('request_stack')->getCurrentRequest();
@@ -148,6 +153,7 @@ class FormBuilderBlockService extends AbstractAdminBlockService
             'block' => $blockContext->getBlock(),
             'settings' => $blockContext->getSettings(),
             'form' => $form->createView(),
+            'formBuilder' => $formBuilder,
             'title_col' => $form_pack['title_col'],
             'size_col' => $form_pack['size_col'],
             'success' => $success,

--- a/Controller/FormBuilderController.php
+++ b/Controller/FormBuilderController.php
@@ -139,16 +139,26 @@ class FormBuilderController extends AbstractController
             $data = $this->buildSingleContent($form, $form_submit);
 
             $patterns = array_map(function ($key) {
-                return '#<' . $key . '>#';
+                return '#<' . quotemeta($key) . '>#';
             }, array_values($data['headers']));
+
+            foreach ($data['data'] as $item) {
+                quotemeta($item);
+            }
+
             $subject = preg_replace($patterns, array_values($data['data']), $form->getSubject());
 
             $message->setSubject($subject);
 
             if ($form->getReplyTo() !== NULL) {
                 $patterns = array_map(function ($key) {
-                    return '#<' . $key . '>#';
+                    return '#<' . quotemeta($key) . '>#';
                 }, array_values($data['headers']));
+
+                foreach ($data['data'] as $item) {
+                    quotemeta($item);
+                }
+
                 $replyTo = preg_replace($patterns, array_values($data['data']), $form->getReplyTo());
 
                 $errors = $this->get('validator')->validate(

--- a/Entity/FormBuilder.php
+++ b/Entity/FormBuilder.php
@@ -107,6 +107,20 @@ class FormBuilder
      */
     private $mailable = true;
 
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="submission_title", type="string", nullable=true)
+     */
+    private $submissionTitle;
+
+    /**
+     * @var null|string
+     *
+     * @ORM\Column(name="submission_text", type="string", nullable=true)
+     */
+    private $submissionText;
+
     public function __construct()
     {
         $this->recipient = array();
@@ -357,6 +371,42 @@ class FormBuilder
     public function setMailable(bool $mailable): self
     {
         $this->mailable = $mailable;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSubmissionTitle(): ?string
+    {
+        return $this->submissionTitle;
+    }
+
+    /**
+     * @param string|null $submissionTitle
+     * @return FormBuilder
+     */
+    public function setSubmissionTitle(?string $submissionTitle): FormBuilder
+    {
+        $this->submissionTitle = $submissionTitle;
+        return $this;
+    }
+
+    /**
+     * @return string|null
+     */
+    public function getSubmissionText(): ?string
+    {
+        return $this->submissionText;
+    }
+
+    /**
+     * @param string|null $submissionText
+     * @return FormBuilder
+     */
+    public function setSubmissionText(?string $submissionText): FormBuilder
+    {
+        $this->submissionText = $submissionText;
         return $this;
     }
 }

--- a/Resources/views/Block/block_form_builder.html.twig
+++ b/Resources/views/Block/block_form_builder.html.twig
@@ -1,7 +1,7 @@
 {% if success is defined and success %}
     <div class="form-success">
-        <h1>{{ 'success_title'|trans }}</h1>
-        <p>{{ 'success_message'|trans }}</p>
+        <h1>{{ formBuilder.getSubmissionTitle|default('success_title'|trans) }}</h1>
+        <p>{{ formBuilder.getSubmissionText|default('success_message'|trans) }}</p>
     </div>
 {% else %}
     {% if formBuilderId is defined and formBuilderId is not null %}

--- a/composer.json
+++ b/composer.json
@@ -14,10 +14,10 @@
     ],
     "require": {
         "php": "^7.1",
-        "sonata-project/block-bundle": "~3.2",
+        "sonata-project/block-bundle": "^3.14",
         "gregwar/captcha-bundle": "^2.0",
         "sonata-project/admin-bundle": "^3.38.0",
-        "doctrine/orm": "^2.4",
+        "doctrine/orm": "^2.5",
         "sensio/framework-extra-bundle": "^5.1.0",
         "sonata-project/exporter": "^1.8",
         "symfony/swiftmailer-bundle": "^2.6.4",


### PR DESCRIPTION
Allow creation of custom submission/success text and message to display after form submission.
+
Fix preg_match issue when using ?* as internal key.