### PR TITLE
Fixed multi checkbox widget constraints

### DIFF
--- a/FormFactory/FormBuilderFactory.php
+++ b/FormFactory/FormBuilderFactory.php
@@ -265,7 +265,7 @@ class FormBuilderFactory
             'required' => $elem->fields->required->value,
             'constraints' => [
                 new Count([
-                    'min' => count($elem->fields->checkboxes->value),
+                    'min' => $elem->fields->required->value ? 1 : 0,
                     'max' => count($elem->fields->checkboxes->value),
                 ])
             ],


### PR DESCRIPTION
Require 1 or 0 minimum checked checkboxes for multiple checkboxes widget based on required bool