### PR TITLE
Remove html5 required attribute from checkboxes

### DIFF
--- a/FormFactory/FormBuilderFactory.php
+++ b/FormFactory/FormBuilderFactory.php
@@ -269,10 +269,6 @@ class FormBuilderFactory
                     'max' => count($elem->fields->checkboxes->value),
                 ])
             ],
-            'choice_attr' => function () use ($elem) {
-                // adds a class like attending_yes, attending_no, etc
-                return ['required' => $elem->fields->required->value];
-            },
         ]);
 
         return [


### PR DESCRIPTION
When 'multiple checkboxes' is required, only minimum 1 should be required.