### PR TITLE
Symfony 5.4 and PHP 8.1

### DIFF
--- a/Admin/FormBuilderAdmin.php
+++ b/Admin/FormBuilderAdmin.php
@@ -28,10 +28,15 @@ class FormBuilderAdmin extends AbstractAdmin
         parent::__construct($code, $class, $baseControllerName);
     }
 
+    protected function configure(): void
+    {
+        $this->getTemplateRegistry()->setTemplate('edit', '@PirastruFormBuilder/CRUD/formbuilder.html.twig');
+    }
+
     /**
      * @param DatagridMapper $datagridMapper
      */
-    protected function configureDatagridFilters(DatagridMapper $datagridMapper)
+    protected function configureDatagridFilters(DatagridMapper $datagridMapper): void
     {
         $datagridMapper
             ->add('recipient')
@@ -41,7 +46,7 @@ class FormBuilderAdmin extends AbstractAdmin
     /**
      * @param ListMapper $listMapper
      */
-    protected function configureListFields(ListMapper $listMapper)
+    protected function configureListFields(ListMapper $listMapper): void
     {
         $listMapper
             ->addIdentifier('name')
@@ -51,7 +56,7 @@ class FormBuilderAdmin extends AbstractAdmin
             ->add('mailable', 'boolean', [
                 'label' => 'Email responses?'
             ])
-            ->add('_action', null, [
+            ->add('_actions', null, [
                 'actions' => [
                     'show' => [],
                     'edit' => [],
@@ -62,7 +67,7 @@ class FormBuilderAdmin extends AbstractAdmin
     /**
      * @param FormMapper $formMapper
      */
-    protected function configureFormFields(FormMapper $formMapper)
+    protected function configureFormFields(FormMapper $formMapper): void
     {
         $formMapper
             ->add('json', HiddenType::class)
@@ -76,15 +81,18 @@ class FormBuilderAdmin extends AbstractAdmin
                 'label' => 'Email responses?',
             ])
             ->add('subject', TextType::class, [
-                'sonata_help' => "You can use &lt;Internal Key&gt; to add variables to your subject. Example: This email is from &lt;Name&gt;",
+                'help' => "You can use &lt;Internal Key&gt; to add variables to your subject. Example: This email is from &lt;Name&gt;",
+                'help_html' => true,
                 'required' => false,
             ])
             ->add('reply_to', TextType::class, [
-                'sonata_help' => "You can use &lt;Internal Key&gt; to add variables to your reply to field. Example: &lt;Email&gt;",
+                'help' => "You can use &lt;Internal Key&gt; to add variables to your reply to field. Example: &lt;Email&gt;",
+                'help_html' => true,
                 'required' => false,
             ])
             ->add('recipient', CollectionType::class, array(
-                    'sonata_help' => "You can use &lt;Internal Key&gt; to add variables to your recipient field. Example: &lt;Email&gt;",
+                    'help' => "You can use &lt;Internal Key&gt; to add variables to your recipient field. Example: &lt;Email&gt;",
+                    'help_html' => true,
                     'entry_type' => EmailType::class,
                     'label' => 'Recipient(s)',
                     'allow_add' => true,
@@ -98,7 +106,8 @@ class FormBuilderAdmin extends AbstractAdmin
                 )
             )
             ->add('recipientCC', CollectionType::class, array(
-                    'sonata_help' => "You can use &lt;Internal Key&gt; to add variables to your recipient CC field. Example: &lt;Email&gt;",
+                    'help' => "You can use &lt;Internal Key&gt; to add variables to your recipient CC field. Example: &lt;Email&gt;",
+                    'help_html' => true,
                     'entry_type' => EmailType::class,
                     'required' => false,
                     'allow_add' => true,
@@ -111,7 +120,8 @@ class FormBuilderAdmin extends AbstractAdmin
                 )
             )
             ->add('recipientBCC', CollectionType::class, array(
-                    'sonata_help' => "You can use &lt;Internal Key&gt; to add variables to your recipient BCC field. Example: &lt;Email&gt;",
+                    'help' => "You can use &lt;Internal Key&gt; to add variables to your recipient BCC field. Example: &lt;Email&gt;",
+                    'help_html' => true,
                     'entry_type' => EmailType::class,
                     'required' => false,
                     'allow_add' => true,
@@ -126,37 +136,24 @@ class FormBuilderAdmin extends AbstractAdmin
             ->add('submissionTitle', TextType::class, [
                 'required' => false,
                 'label' => 'Custom submit title',
-                'sonata_help' => 'Customize thank you title after successful form submission',
+                'help' => 'Customize thank you title after successful form submission',
             ])
             ->add('submissionText', TextareaType::class, [
                 'required' => false,
                 'label' => 'Custom submit text',
-                'sonata_help' => 'Customize thank you text after successful form submission',
+                'help' => 'Customize thank you text after successful form submission',
             ]);
-    }
-
-    public function getTemplate($name)
-    {
-        switch ($name) {
-            case 'edit':
-                return 'PirastruFormBuilderBundle:CRUD:formbuilder.html.twig';
-                break;
-            default:
-                return parent::getTemplate($name);
-                break;
-        }
     }
 
     /**
      * @param ShowMapper $showMapper
      */
-    protected function configureShowFields(ShowMapper $showMapper)
+    protected function configureShowFields(ShowMapper $showMapper): void
     {
         $showMapper
             ->add('name')
             ->add('recipient')
-            ->add('export', null, ['template' => 'PirastruFormBuilderBundle:CRUD:table_export_form.html.twig'])
-            ->add('submissions', null, array('template' => 'PirastruFormBuilderBundle:CRUD:table_show_field.html.twig'));
+            ->add('submissions', null, array('template' => '@PirastruFormBuilder/CRUD/table_show_field.html.twig'));
     }
 
     /**
@@ -182,12 +179,8 @@ class FormBuilderAdmin extends AbstractAdmin
 
     }
 
-    public function getNewInstance()
+    public function alterNewInstance(object $object): void
     {
-        $instance = parent::getNewInstance();
-
         $instance->setPersistable(true);
-
-        return $instance;
     }
 }

--- a/Block/FormBuilderBlockService.php
+++ b/Block/FormBuilderBlockService.php
@@ -7,92 +7,64 @@
 
 namespace Pirastru\FormBuilderBundle\Block;
 
+use Doctrine\ORM\EntityManagerInterface;
+use Pirastru\FormBuilderBundle\Admin\FormBuilderAdmin;
+use Pirastru\FormBuilderBundle\Controller\FormBuilderController;
 use Pirastru\FormBuilderBundle\Entity\FormBuilder;
 use Sonata\AdminBundle\Form\Type\ModelListType;
 use Sonata\BlockBundle\Block\BlockContextInterface;
-use Sonata\BlockBundle\Block\Service\AbstractAdminBlockService;
+use Sonata\BlockBundle\Block\Service\AbstractBlockService;
+use Sonata\BlockBundle\Block\Service\EditableBlockService;
+use Sonata\BlockBundle\Form\Mapper\FormMapper;
+use Sonata\BlockBundle\Meta\Metadata;
+use Sonata\BlockBundle\Meta\MetadataInterface;
 use Sonata\Form\Type\ImmutableArrayType;
+use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\Form\Form;
 use Symfony\Component\Form\FormBuilderInterface;
+use Symfony\Component\HttpFoundation\RequestStack;
 use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\HttpFoundation\Response;
-use Symfony\Bundle\FrameworkBundle\Templating\EngineInterface;
-use Sonata\AdminBundle\Form\FormMapper;
-use Sonata\CoreBundle\Validator\ErrorElement;
-use Symfony\Component\DependencyInjection\ContainerInterface;
 use Sonata\BlockBundle\Model\BlockInterface;
+use Twig\Environment;
 
 /**
  * @author     Andrea Pirastru
  */
-class FormBuilderBlockService extends AbstractAdminBlockService
+class FormBuilderBlockService extends AbstractBlockService implements EditableBlockService
 {
-    private $container;
-
-    protected $formBuilderAdmin;
-
-    /**
-     * @param string             $name
-     * @param EngineInterface    $templating
-     * @param ContainerInterface $container
-     */
-    public function __construct($name, EngineInterface $templating, ContainerInterface $container)
-    {
-        parent::__construct($name, $templating);
-
-        $this->container = $container;
+    public function __construct(
+        Environment $twig,
+        private readonly RequestStack $requestStack,
+        private readonly EntityManagerInterface $entityManager,
+        private readonly FormBuilderAdmin $formBuilderAdmin,
+        private readonly FormBuilderController $formBuilderController,
+    ) {
+        parent::__construct($twig);
     }
 
     /**
      * {@inheritdoc}
      */
-    public function configureSettings(OptionsResolver $resolver)
+    public function configureSettings(OptionsResolver $resolver): void
     {
         $resolver->setDefaults([
-            'template' => 'PirastruFormBuilderBundle:Block:block_form_builder.html.twig',
+            'template' => '@PirastruFormBuilder/Block/block_form_builder.html.twig',
             'formBuilderId' => null,
         ]);
     }
 
-    /**
-     * {@inheritdoc}
-     */
-    public function buildEditForm(FormMapper $formMapper, BlockInterface $block)
+    public function getFormBuilderAdmin(): FormBuilderAdmin
     {
-        $formMapper->add('settings', ImmutableArrayType::class, [
-            'keys' => [
-                [$this->getFieldFormBuilder($formMapper), null, []],
-            ],
-        ]);
-    }
-
-    /**
-     * @return mixed
-     */
-    public function getFormBuilderAdmin()
-    {
-        if (!$this->formBuilderAdmin) {
-            $this->formBuilderAdmin = $this->container->get('pirastru_form_builder.admin');
-        }
-
         return $this->formBuilderAdmin;
     }
 
-    /**
-     * @param FormMapper $formMapper
-     *
-     * @return FormBuilderInterface
-     */
-    protected function getFieldFormBuilder(FormMapper $formMapper)
+    protected function getFieldFormBuilder(FormMapper $formMapper): FormBuilderInterface
     {
         // simulate an association ...
-        $fieldDescription = $this->getFormBuilderAdmin()->getModelManager()->getNewFieldDescriptionInstance($this->formBuilderAdmin->getClass(), 'form_builder');
+        $fieldDescription = $this->getFormBuilderAdmin()->createFieldDescription('form_builder');
         $fieldDescription->setAssociationAdmin($this->getFormBuilderAdmin());
         $fieldDescription->setAdmin($formMapper->getAdmin());
-        $fieldDescription->setAssociationMapping([
-            'fieldName' => 'form_builder',
-            'type' => \Doctrine\ORM\Mapping\ClassMetadataInfo::MANY_TO_ONE,
-        ]);
 
         return $formMapper->create('formBuilderId', ModelListType::class, [
             'sonata_field_description' => $fieldDescription,
@@ -106,20 +78,13 @@ class FormBuilderBlockService extends AbstractAdminBlockService
     /**
      * {@inheritdoc}
      */
-    public function validateBlock(ErrorElement $errorElement, BlockInterface $block)
-    {
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function execute(BlockContextInterface $blockContext, Response $response = null)
+    public function execute(BlockContextInterface $blockContext, Response $response = null): Response
     {
         $formBuilderId = $blockContext->getBlock()->getSetting('formBuilderId');
 
         /** @var FormBuilder $formBuilder */
-        $formBuilder = $this->container->get('doctrine')
-            ->getRepository('PirastruFormBuilderBundle:FormBuilder')
+        $formBuilder = $this->entityManager
+            ->getRepository(FormBuilder::class)
             ->findOneBy(['id' => $formBuilderId]);
 
         // In case the FormBuilder Object is not defined
@@ -128,13 +93,13 @@ class FormBuilderBlockService extends AbstractAdminBlockService
             return $this->renderResponse($blockContext->getTemplate(), [], $response);
         }
 
-        $form_pack = $this->container->get('pirastru_form_builder.controller')
+        $form_pack = $this->formBuilderController
             ->generateFormFromFormBuilder($formBuilder);
 
         /** @var Form $form */
         $form = $form_pack['form'];
         $success = false;
-        $request = $this->container->get('request_stack')->getCurrentRequest();
+        $request = $this->requestStack->getCurrentRequest();
         $form->handleRequest($request);
 
         if ($form->isSubmitted() && $form->isValid()) {
@@ -143,7 +108,7 @@ class FormBuilderBlockService extends AbstractAdminBlockService
              ***************************************/
             $this->preUpdate($blockContext->getBlock());
 
-            $this->container->get('pirastru_form_builder.controller')
+            $this->formBuilderController
                 ->submitOperations($formBuilder, $form_pack['title_col']);
 
             $success = true;
@@ -165,13 +130,13 @@ class FormBuilderBlockService extends AbstractAdminBlockService
     /**
      * {@inheritdoc}
      */
-    public function load(BlockInterface $block)
+    public function load(BlockInterface $block): void
     {
         $formBuilderId = $block->getSetting('formBuilderId');
 
         if ($formBuilderId) {
-            $formBuilderId = $this->container->get('doctrine')
-                ->getRepository('PirastruFormBuilderBundle:FormBuilder')
+            $formBuilderId = $this->entityManager
+                ->getRepository(FormBuilder::class)
                 ->findOneBy(['id' => $formBuilderId]);
         }
 
@@ -197,8 +162,32 @@ class FormBuilderBlockService extends AbstractAdminBlockService
     /**
      * {@inheritdoc}
      */
-    public function getName()
+    public function getName(): string
     {
         return 'Form';
+    }
+
+    public function configureEditForm(FormMapper $form, BlockInterface $block): void
+    {
+        $form->add('settings', ImmutableArrayType::class, [
+            'keys' => [
+                [$this->getFieldFormBuilder($form), null, []],
+            ],
+        ]);
+    }
+
+    public function configureCreateForm(FormMapper $form, BlockInterface $block): void
+    {
+        $this->configureEditForm($form, $block);
+    }
+
+    public function validate(ErrorElement $errorElement, BlockInterface $block): void
+    {
+        // NOOP
+    }
+
+    public function getMetadata(): MetadataInterface
+    {
+        return new Metadata($this->getName());
     }
 }

--- a/DependencyInjection/Configuration.php
+++ b/DependencyInjection/Configuration.php
@@ -18,8 +18,8 @@ class Configuration implements ConfigurationInterface
      */
     public function getConfigTreeBuilder()
     {
-        $treeBuilder = new TreeBuilder();
-        $rootNode = $treeBuilder->root('pirastru_formbuilder');
+        $treeBuilder = new TreeBuilder('pirastru_formbuilder');
+        $rootNode = $treeBuilder->getRootNode();
         // Here you should define the parameters that are allowed to
         // configure your bundle. See the documentation linked above for
         // more information on that topic.

--- a/Event/FormDataEvent.php
+++ b/Event/FormDataEvent.php
@@ -2,19 +2,12 @@
 
 namespace Pirastru\FormBuilderBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class FormDataEvent extends Event
 {
-    protected array $data;
-
-    /**
-     * @param array $data
-     */
-    public function __construct(array $data)
-    {
-        $this->data = $data;
-    }
+    public function __construct(protected array $data)
+    {}
 
     public function getData(): array
     {

--- a/Event/MailEvent.php
+++ b/Event/MailEvent.php
@@ -1,56 +1,30 @@
 <?php
 namespace Pirastru\FormBuilderBundle\Event;
 
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Component\Mime\Email;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class MailEvent extends Event
 {
-    /**
-     * @var \Swift_Message
-     */
-    private $message;
+    public function __construct(private Email $message, private array $formData)
+    {}
 
-    /** @var array */
-    private $formData;
-
-    /**
-     * MailEvent constructor.
-     * @param \Swift_Message $message
-     */
-    public function __construct(\Swift_Message $message, array $formData)
-    {
-        $this->message = $message;
-        $this->formData = $formData;
-    }
-
-    /**
-     * @return array
-     */
-    public function getFormData()
+    public function getFormData(): array
     {
         return $this->formData;
     }
 
-    /**
-     * @param array $formData
-     */
-    public function setFormData($formData)
+    public function setFormData(array $formData): void
     {
         $this->formData = $formData;
     }
 
-    /**
-     * @return \Swift_Message
-     */
-    public function getMessage()
+    public function getMessage(): Email
     {
         return $this->message;
     }
 
-    /**
-     * @param \Swift_Message $message
-     */
-    public function setMessage(\Swift_Message $message)
+    public function setMessage(Email $message): void
     {
         $this->message = $message;
     }

--- a/Event/SubmissionEvent.php
+++ b/Event/SubmissionEvent.php
@@ -3,7 +3,7 @@
 namespace Pirastru\FormBuilderBundle\Event;
 
 use Pirastru\FormBuilderBundle\Entity\FormBuilderSubmission;
-use Symfony\Component\EventDispatcher\Event;
+use Symfony\Contracts\EventDispatcher\Event;
 
 class SubmissionEvent extends Event
 {

--- a/FormFactory/FormBuilderFactory.php
+++ b/FormFactory/FormBuilderFactory.php
@@ -50,7 +50,7 @@ class FormBuilderFactory
             'constraints' => [
                 new Email(),
             ],
-            'sonata_help' => $elem->fields->helptext->value,
+            'help' => $elem->fields->helptext->value,
         ]);
 
         return [
@@ -82,7 +82,7 @@ class FormBuilderFactory
                     'message' => 'Invalid format: dd-mm-yyyy'
                 ]),
             ],
-            'sonata_help' => $elem->fields->helptext->value,
+            'help' => $elem->fields->helptext->value,
         ]);
 
         return [
@@ -114,7 +114,7 @@ class FormBuilderFactory
                     'message' => 'Invalid telephone number.',
                 ])
             ],
-            'sonata_help' => $elem->fields->helptext->value,
+            'help' => $elem->fields->helptext->value,
         ]);
 
         return [
@@ -139,7 +139,7 @@ class FormBuilderFactory
             'attr' => [
                 'placeholder' => $elem->fields->placeholder->value,
             ],
-            'sonata_help' => $elem->fields->helptext->value,
+            'help' => $elem->fields->helptext->value,
         ]);
 
         return [
@@ -164,7 +164,7 @@ class FormBuilderFactory
             'attr' => [
                 'placeholder' => $elem->fields->textarea->value,
             ],
-            'sonata_help' => $elem->fields->helptext->value,
+            'help' => $elem->fields->helptext->value,
         ]);
 
         return [
@@ -437,7 +437,7 @@ class FormBuilderFactory
             'label_attr' => [
                 'style' => 'display:none;',
             ],
-            'sonata_help' => $elem->fields->helptext->value,
+            'help' => $elem->fields->helptext->value,
         ));
 
         return [

--- a/Handler/FileHandlerInterface.php
+++ b/Handler/FileHandlerInterface.php
@@ -3,10 +3,11 @@
 namespace Pirastru\FormBuilderBundle\Handler;
 
 use Pirastru\FormBuilderBundle\Entity\FormBuilderSubmission;
+use Symfony\Component\Mime\Email;
 
 interface FileHandlerInterface
 {
     public function normalizeForPersistence(FormBuilderSubmission $submission): void;
-    public function attachFilesToMail(\Swift_Message $message, array $data): void;
+    public function attachFilesToMail(Email $email, array $data): void;
     public function normalizeUploadedFiles(array $data): array;
 }

--- a/Handler/SimpleFileHandler.php
+++ b/Handler/SimpleFileHandler.php
@@ -4,6 +4,7 @@ namespace Pirastru\FormBuilderBundle\Handler;
 
 use Pirastru\FormBuilderBundle\Entity\FormBuilderSubmission;
 use Symfony\Component\HttpFoundation\File\UploadedFile;
+use Symfony\Component\Mime\Email;
 
 class SimpleFileHandler implements FileHandlerInterface
 {
@@ -29,13 +30,16 @@ class SimpleFileHandler implements FileHandlerInterface
         return $data;
     }
 
-    public function attachFilesToMail(\Swift_Message $message, array $data): void
+    public function attachFilesToMail(Email $email, array $data): void
     {
         foreach ($data['files'] as $header => $files) {
             foreach ($files as $file) {
-                $attachment = \Swift_Attachment::fromPath($file->getPathname());
-                $attachment->setFilename(sprintf('[%s] %s', $header, $file->getClientOriginalName()));
-                $message->attach($attachment);
+
+                $email->attachFromPath(
+                    $file->getPathname(),
+                    sprintf('[%s] %s', $header, $file->getClientOriginalName()),
+                    'text/csv'
+                );
             }
         }
     }

--- a/Resources/config/services.yml
+++ b/Resources/config/services.yml
@@ -4,24 +4,26 @@ parameters:
 services:
     pirastru_form_builder.admin:
         class: Pirastru\FormBuilderBundle\Admin\FormBuilderAdmin
-        arguments: [~, Pirastru\FormBuilderBundle\Entity\FormBuilder, PirastruFormBuilderBundle:FormBuilderAdmin, "@service_container"]
-        calls:
-            - [setTemplate, ['edit', 'PirastruFormBuilderBundle:CRUD:formbuilder.html.twig']]
+        arguments: [~, Pirastru\FormBuilderBundle\Entity\FormBuilder, Pirastru\FormBuilderBundle\Controller\FormBuilderAdminController, "@service_container"]
         tags:
-            - {name: sonata.admin, manager_type: orm, group: Form, label: "%pirastru_form_builder.label%" }
+            - { name: sonata.admin, manager_type: orm, group: Form, label: "%pirastru_form_builder.label%" }
 
     pirastru_form_builder.block:
         class: Pirastru\FormBuilderBundle\Block\FormBuilderBlockService
         arguments:
-            - "pirastru_form_builder.block"
-            - "@templating.engine.twig"
-            - "@service_container"
+            - "@twig"
+            - "@request_stack"
+            - "@doctrine.orm.entity_manager"
+            - "@pirastru_form_builder.admin"
+            - "@pirastru_form_builder.controller"
         tags:
             - {name: "sonata.block"}
 
     pirastru_form_builder.controller:
         class: Pirastru\FormBuilderBundle\Controller\FormBuilderController
         public: true
+        arguments:
+            $mailer: '@mailer'
         calls:
             - [setContainer, ["@service_container"]]
 
@@ -35,3 +37,7 @@ services:
     Pirastru\FormBuilderBundle\Handler\SimpleFileHandler: ~
 
     Pirastru\FormBuilderBundle\Handler\FileHandlerInterface: '@Pirastru\FormBuilderBundle\Handler\SimpleFileHandler'
+
+    Pirastru\FormBuilderBundle\Controller\FormBuilderAdminController:
+        autoconfigure: true
+        autowire: true

--- a/Resources/views/Block/_form_theme.html.twig
+++ b/Resources/views/Block/_form_theme.html.twig
@@ -68,14 +68,6 @@
     {%- endif -%}
 {%- endblock form_label %}
 
-{% block form_widget_simple %}
-    {{ parent() }}
-
-    {% if sonata_help is defined and sonata_help is not same as ('') %}
-        <span class="help-block">{{ sonata_help }}</span>
-    {% endif %}
-{% endblock %}
-
 {% block double_button_row %}
     <div class="form-group">
         {%- for child in form %}

--- a/Resources/views/CRUD/formbuilder.html.twig
+++ b/Resources/views/CRUD/formbuilder.html.twig
@@ -1,4 +1,4 @@
-{% extends 'SonataAdminBundle:CRUD:edit.html.twig' %}
+{% extends '@SonataAdmin/CRUD/edit.html.twig' %}
 
 {% block stylesheets %}
     {{ parent() }}
@@ -20,7 +20,7 @@
             } );
         });
 
-        {% if sonata_admin.adminPool.getOption('confirm_exit') %}
+        {% if sonata_config.getOption('confirm_exit') %}
         if (typeof Admin !== "undefined") {
             Admin.read_config();
             Admin.config['CONFIRM_EXIT'] = false;
@@ -30,8 +30,7 @@
 {% endblock %}
 
 {% block form %}
-
-    <div class="box box-success">
+   <div class="box box-success">
         <div class="box-header">
             <h4 class="box-title">
                 Form Builder

--- a/Resources/views/CRUD/table_show_field.html.twig
+++ b/Resources/views/CRUD/table_show_field.html.twig
@@ -1,6 +1,6 @@
 <th>
     {% block name %}
-        {{ admin.trans(field_description.label, {}, field_description.translationDomain) }}
+        {{ field_description.label|trans({}, field_description.translationDomain) }}
     {% endblock %}
 </th>
 <td>
@@ -9,63 +9,67 @@
         {% set form_array = json_decode(object.json) %}
 
         <tr>
-            {% for key,value in object.columns if key|slice(0, 6) != 'button' %}
-                <th>{{ value }}</th>
+            {% for key,value in object.columns %}
+              {% if key|slice(0, 6) != 'button' %}
+                  <th>{{ value }}</th>
+              {% endif %}
             {% endfor %}
         </tr>
 
         {% for submit_line in object.submissions %}
             {% set submit_line = submit_line.value %}
             <tr>
-                {% for key,value in object.columns if key|slice(0, 6) != 'button' %}
-                    {% set el_k = key|split('_') %}
-                    {% if  key|slice(0, 5) == 'radio' %}
-                        <td>
-                            {% if submit_line[key] is defined and submit_line[key] != '' %}
-                                {{ form_array[el_k[1]].fields.radios.value[submit_line[key]] }}
-                            {% endif %}
-                        </td>
-                    {% elseif key|slice(0, 6) == 'choice' %}
-                        <td>
-                            {% if submit_line[key] is defined %}
-                                {% if is_array(submit_line[key]) %}
-                                    <ul>
-                                        {% for v in submit_line[key] %}
-                                            <li>{{ form_array[el_k[1]].fields.options.value[v] }}</li>
-                                        {% endfor %}
-                                    </ul>
-                                {% else %}
-                                    {% if submit_line[key] != '' %}
-                                        {{ form_array[el_k[1]].fields.options.value[submit_line[key]] }}
+                {% for key,value in object.columns %}
+                    {% if key|slice(0, 6) != 'button' %}
+                        {% set el_k = key|split('_') %}
+                        {% if  key|slice(0, 5) == 'radio' %}
+                            <td>
+                                {% if submit_line[key] is defined and submit_line[key] != '' %}
+                                    {{ form_array[el_k[1]].fields.radios.value[submit_line[key]] }}
+                                {% endif %}
+                            </td>
+                        {% elseif key|slice(0, 6) == 'choice' %}
+                            <td>
+                                {% if submit_line[key] is defined %}
+                                    {% if is_array(submit_line[key]) %}
+                                        <ul>
+                                            {% for v in submit_line[key] %}
+                                                <li>{{ form_array[el_k[1]].fields.options.value[v] }}</li>
+                                            {% endfor %}
+                                        </ul>
+                                    {% else %}
+                                        {% if submit_line[key] != '' %}
+                                            {{ form_array[el_k[1]].fields.options.value[submit_line[key]] }}
+                                        {% endif %}
                                     {% endif %}
                                 {% endif %}
-                            {% endif %}
-                        </td>
-                    {% elseif key|slice(0, 5) == 'check' %}
-                        <td>
+                            </td>
+                        {% elseif key|slice(0, 5) == 'check' %}
+                            <td>
 
-                            {% if submit_line[key] is defined %}
-                                {% if is_array(submit_line[key]) %}
-                                    <ul>
-                                        {% for v in submit_line[key] %}
-                                            <li>{{ form_array[el_k[1]].fields.checkboxes.value[v] }}</li>
-                                        {% endfor %}
-                                    </ul>
-                                {% else %}
-                                    {{ form_array[el_k[1]].fields.checkboxes.value[submit_line[key]] }}
+                                {% if submit_line[key] is defined %}
+                                    {% if is_array(submit_line[key]) %}
+                                        <ul>
+                                            {% for v in submit_line[key] %}
+                                                <li>{{ form_array[el_k[1]].fields.checkboxes.value[v] }}</li>
+                                            {% endfor %}
+                                        </ul>
+                                    {% else %}
+                                        {{ form_array[el_k[1]].fields.checkboxes.value[submit_line[key]] }}
+                                    {% endif %}
                                 {% endif %}
-                            {% endif %}
-                        </td>
-                    {% elseif submit_line[key] is defined and submit_line[key] is iterable %}
-                        <td>
-                            {{ submit_line[key]|join(', ') }}
-                        </td>
-                    {% elseif submit_line[key] is defined %}
-                        <td>
-                            {{ submit_line[key] }}
-                        </td>
-                    {% else %}
-                        <td></td>
+                            </td>
+                        {% elseif submit_line[key] is defined and submit_line[key] is iterable %}
+                            <td>
+                                {{ submit_line[key]|join(', ') }}
+                            </td>
+                        {% elseif submit_line[key] is defined %}
+                            <td>
+                                {{ submit_line[key] }}
+                            </td>
+                        {% else %}
+                            <td></td>
+                        {% endif %}
                     {% endif %}
                 {% endfor %}
 

--- a/composer.json
+++ b/composer.json
@@ -13,16 +13,25 @@
         }
     ],
     "require": {
-        "php": "^7.1",
-        "symfony/symfony": "^3.4 || ^4.4",
-        "sonata-project/block-bundle": "^3.14",
-        "gregwar/captcha-bundle": "^2.0",
-        "sonata-project/admin-bundle": "^3.38.0",
+        "php": "^8.1",
+        "symfony/event-dispatcher": "^5.4",
+        "symfony/http-kernel": "^5.4",
+        "symfony/dependency-injection": "^5.4",
+        "symfony/form": "^5.4",
+        "symfony/options-resolver": "^5.4",
+        "symfony/validator": "^5.4",
+        "symfony/http-foundation": "^5.4",
+        "symfony/framework-bundle": "^5.4",
+        "symfony/config": "^5.4",
+        "symfony/routing": "^5.4",
+        "sonata-project/block-bundle": "^4.0",
+        "gregwar/captcha-bundle": "^2.2",
+        "sonata-project/admin-bundle": "^4.0",
         "doctrine/orm": "^2.5",
-        "sensio/framework-extra-bundle": "^5.1.0",
-        "sonata-project/exporter": "^1.8",
-        "symfony/swiftmailer-bundle": "^2.6.4 || ^3.2",
-      "ext-json": "*"
+        "sonata-project/exporter": "^3.0",
+        "ext-json": "*",
+        "symfony/mailer": "^5.4",
+        "symfony/twig-bundle": "^5.4"
     },
     "autoload": {
         "psr-4": { "Pirastru\\FormBuilderBundle\\": "" }


### PR DESCRIPTION
Upgrade to Symfony 5.4, also require only the specific components instead of the full symfony framework. Update php requirement to 8.1. So, now only versions with active support are required.