### PR TITLE
Add action delete to submissions table (GDPR)

### DIFF
--- a/Admin/FormBuilderAdmin.php
+++ b/Admin/FormBuilderAdmin.php
@@ -7,6 +7,7 @@ use Sonata\AdminBundle\Admin\AbstractAdmin;
 use Sonata\AdminBundle\Datagrid\DatagridMapper;
 use Sonata\AdminBundle\Datagrid\ListMapper;
 use Sonata\AdminBundle\Form\FormMapper;
+use Sonata\AdminBundle\Route\RouteCollectionInterface;
 use Sonata\AdminBundle\Show\ShowMapper;
 use Sonata\Form\Validator\ErrorElement;
 use Symfony\Component\DependencyInjection\ContainerInterface;
@@ -185,5 +186,10 @@ class FormBuilderAdmin extends AbstractAdmin
 
             return $groups;
         };
+    }
+
+    protected function configureRoutes(RouteCollectionInterface $collection): void
+    {
+        $collection->add('submission_delete', $this->getRouterIdParameter().'/submissions/{submission_id}/delete');
     }
 }

--- a/Controller/FormBuilderAdminController.php
+++ b/Controller/FormBuilderAdminController.php
@@ -15,7 +15,6 @@ use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
 
 class FormBuilderAdminController extends CRUDController
 {
-    #[Route(path: "/submissions/{submission_id}/delete", name: "admin_pirastru_formbuilder_formbuilder_submission_delete", methods: "POST")]
     #[Entity("submission", expr: "repository.find(submission_id)")]
     public function submissionDeleteAction(Request $request, FormBuilder $formBuilder, FormBuilderSubmission $submission): Response
     {

--- a/Controller/FormBuilderAdminController.php
+++ b/Controller/FormBuilderAdminController.php
@@ -2,8 +2,77 @@
 
 namespace Pirastru\FormBuilderBundle\Controller;
 
+use Pirastru\FormBuilderBundle\Entity\FormBuilder;
+use Pirastru\FormBuilderBundle\Entity\FormBuilderSubmission;
 use Sonata\AdminBundle\Controller\CRUDController;
+use Sonata\AdminBundle\Exception\ModelManagerException;
+use Sonata\AdminBundle\Exception\ModelManagerThrowable;
+use Symfony\Component\HttpFoundation\RedirectResponse;
+use Symfony\Component\HttpFoundation\Response;
+use Symfony\Component\Routing\Annotation\Route;
+use Symfony\Component\HttpFoundation\Request;
+use Sensio\Bundle\FrameworkExtraBundle\Configuration\Entity;
 
 class FormBuilderAdminController extends CRUDController
 {
+    #[Route(path: "/submissions/{submission_id}/delete", name: "admin_pirastru_formbuilder_formbuilder_submission_delete", methods: "POST")]
+    #[Entity("submission", expr: "repository.find(submission_id)")]
+    public function submissionDeleteAction(Request $request, FormBuilder $formBuilder, FormBuilderSubmission $submission): Response
+    {
+        if (Request::METHOD_GET === $request->getMethod()) {
+            return $this->renderWithExtraParams('@PirastruFormBuilder/CRUD/submission_delete.html.twig', [
+                'form' => $formBuilder,
+                'submission' => $submission,
+                'action' => 'delete',
+                'csrf_token' => $this->getCsrfToken('sonata.delete')
+            ]);
+        }
+
+        $this->admin->checkAccess('delete', $formBuilder);
+
+        if (\in_array($request->getMethod(), [Request::METHOD_POST, Request::METHOD_DELETE], true)) {
+            $objectName = $this->admin->toString($submission);
+
+            $this->validateCsrfToken($request, 'sonata.delete');
+
+            try {
+                $this->admin->delete($submission);
+
+                $this->addFlash(
+                    'sonata_flash_success',
+                    $this->trans(
+                        'flash_delete_success',
+                        ['%name%' => $this->escapeHtml($objectName)],
+                        'SonataAdminBundle'
+                    )
+                );
+            } catch (ModelManagerException $e) {
+                // NEXT_MAJOR: Remove this catch.
+                $this->handleModelManagerException($e);
+
+                $this->addFlash(
+                    'sonata_flash_error',
+                    $this->trans(
+                        'flash_delete_error',
+                        ['%name%' => $this->escapeHtml($objectName)],
+                        'SonataAdminBundle'
+                    )
+                );
+            } catch (ModelManagerThrowable $e) {
+                $errorMessage = $this->handleModelManagerThrowable($e);
+
+                $this->addFlash(
+                    'sonata_flash_error',
+                    $errorMessage ?? $this->trans(
+                    'flash_delete_error',
+                    ['%name%' => $this->escapeHtml($objectName)],
+                    'SonataAdminBundle'
+                )
+                );
+            }
+
+            return new RedirectResponse($this->admin->generateUrl('show', ["id" => $formBuilder->getId()]));
+        }
+
+    }
 }

--- a/Entity/FormBuilderSubmission.php
+++ b/Entity/FormBuilderSubmission.php
@@ -62,6 +62,15 @@ class FormBuilderSubmission
         $this->form = $form;
     }
 
+    public function __toString(): string
+    {
+        $firstFormColumnValue = (array_values($this->form->getColumns())[0] && array_values($this->getValue())[0])
+            ? array_values($this->form->getColumns())[0] . ": " . array_values($this->getValue())[0]
+            : '';
+
+        return "id: " . $this->id . " - " . $firstFormColumnValue;
+    }
+
     /**
      * @return int
      */

--- a/Resources/public/BootstrapFormBuilder/assets/js/templates/snippet/linktext.html
+++ b/Resources/public/BootstrapFormBuilder/assets/js/templates/snippet/linktext.html
@@ -4,6 +4,6 @@
         &nbsp;
     </div>
     <div class="col-md-8">
-        <strong><p>{{ textbeforelink }} <a href="{{ url }}">{{ cta }}</a> {{ textafterlink }}</p></strong>
+        <p>{{ textbeforelink }} <a href="{{ url }}">{{ cta }}</a> {{ textafterlink }}</p>
     </div>
 </div>

--- a/Resources/views/CRUD/submission_delete.html.twig
+++ b/Resources/views/CRUD/submission_delete.html.twig
@@ -33,7 +33,7 @@ file that was distributed with this source code.
                 {{ 'message_delete_confirmation'|trans({'%object%': admin.toString(submission)}, 'SonataAdminBundle') }}
             </div>
             <div class="box-footer clearfix">
-              <form method="POST" action="{{ path('admin_pirastru_formbuilder_formbuilder_submission_delete', { "id": form.id, "submission_id": submission.id }) }}">
+              <form method="POST" action="{{ admin.generateUrl('submission_delete', { "id": form.id, "submission_id": submission.id }) }}">
                     <input type="hidden" name="_method" value="DELETE">
                     <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
 
@@ -41,9 +41,9 @@ file that was distributed with this source code.
                     {% if admin.hasRoute('edit') and admin.hasAccess('edit', form) %}
                         {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
 
-                        <a class="btn btn-success" href="{{ admin.generateObjectUrl('edit', form) }}">
-                            <i class="fas fa-pencil-alt" aria-hidden="true"></i>
-                            {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}</a>
+                        <a class="btn btn-success" href="{{ admin.generateObjectUrl('show', form) }}">
+                          <i class="fas fa-eye"></i>
+                          {{ 'link_action_show'|trans({}, 'SonataAdminBundle') }}</a>
                     {% endif %}
                 </form>
             </div>

--- a/Resources/views/CRUD/submission_delete.html.twig
+++ b/Resources/views/CRUD/submission_delete.html.twig
@@ -1,0 +1,52 @@
+{#
+
+This file is part of the Sonata package.
+
+(c) Thomas Rabaix <thomas.rabaix@sonata-project.org>
+
+For the full copyright and license information, please view the LICENSE
+file that was distributed with this source code.
+
+#}
+
+{% extends base_template %}
+
+{%- block actions -%}
+    {% include '@SonataAdmin/CRUD/action_buttons.html.twig' %}
+{%- endblock -%}
+
+{%- block tab_menu -%}
+    {{ knp_menu_render(admin.sidemenu(action), {
+        'currentClass': 'active',
+        'template': get_global_template('tab_menu_template')
+    }, 'twig') }}
+{%- endblock -%}
+
+{% block content %}
+    <div class="sonata-ba-delete">
+
+        <div class="box box-danger">
+            <div class="box-header">
+                <h3 class="box-title">{{ 'title_delete'|trans({}, 'SonataAdminBundle') }}</h3>
+            </div>
+            <div class="box-body">
+                {{ 'message_delete_confirmation'|trans({'%object%': admin.toString(submission)}, 'SonataAdminBundle') }}
+            </div>
+            <div class="box-footer clearfix">
+              <form method="POST" action="{{ path('admin_pirastru_formbuilder_formbuilder_submission_delete', { "id": form.id, "submission_id": submission.id }) }}">
+                    <input type="hidden" name="_method" value="DELETE">
+                    <input type="hidden" name="_sonata_csrf_token" value="{{ csrf_token }}">
+
+                    <button type="submit" name="btn_delete" class="btn btn-danger"><i class="fas fa-trash-alt" aria-hidden="true"></i> {{ 'btn_delete'|trans({}, 'SonataAdminBundle') }}</button>
+                    {% if admin.hasRoute('edit') and admin.hasAccess('edit', form) %}
+                        {{ 'delete_or'|trans({}, 'SonataAdminBundle') }}
+
+                        <a class="btn btn-success" href="{{ admin.generateObjectUrl('edit', form) }}">
+                            <i class="fas fa-pencil-alt" aria-hidden="true"></i>
+                            {{ 'link_action_edit'|trans({}, 'SonataAdminBundle') }}</a>
+                    {% endif %}
+                </form>
+            </div>
+        </div>
+    </div>
+{% endblock %}

--- a/Resources/views/CRUD/table_show_field.html.twig
+++ b/Resources/views/CRUD/table_show_field.html.twig
@@ -14,10 +14,11 @@
                   <th>{{ value }}</th>
               {% endif %}
             {% endfor %}
+          <th>Actions</th>
         </tr>
 
-        {% for submit_line in object.submissions %}
-            {% set submit_line = submit_line.value %}
+        {% for submission in object.submissions %}
+            {% set submit_line = submission.value %}
             <tr>
                 {% for key,value in object.columns %}
                     {% if key|slice(0, 6) != 'button' %}
@@ -73,6 +74,11 @@
                     {% endif %}
                 {% endfor %}
 
+              <td>
+                <form method="GET" action="{{ path('admin_pirastru_formbuilder_formbuilder_submission_delete', { "id": object.id, "submission_id": submission.id }) }}">
+                  <button type="submit" class="btn btn-danger">Delete</button>
+                </form>
+              </td>
             </tr>
         {% else %}
             Never submitted!

--- a/Resources/views/CRUD/table_show_field.html.twig
+++ b/Resources/views/CRUD/table_show_field.html.twig
@@ -75,9 +75,9 @@
                 {% endfor %}
 
               <td>
-                <form method="GET" action="{{ path('admin_pirastru_formbuilder_formbuilder_submission_delete', { "id": object.id, "submission_id": submission.id }) }}">
-                  <button type="submit" class="btn btn-danger">Delete</button>
-                </form>
+                <a href="{{ admin.generateUrl('submission_delete', { "id": object.id, "submission_id": submission.id }) }}" class="btn btn-danger">
+                  {{ 'action_delete'|trans({}, 'SonataAdminBundle') }}
+                </a>
               </td>
             </tr>
         {% else %}


### PR DESCRIPTION
Pull-request die het mogelijk maakt om submission te kunnen verwijderen (verplicht door de GDPR)

Nieuwe route aangemaakt -> submission_delete

Niewe controller action die het deleten van submissions verwerkt. Doet ongeveer het zelfde als de sonata delete action. Alleen is het verwijderen van een relation op de formbuilder niet mogelijk via de sonata delete action.

GET request -> Bevestiging Template laten zien
POST request -> Verwijderen gekozen submission

In table zelf is er een nieuwe column bij gekomen genaamd action.